### PR TITLE
Fixed Planner Resizing and Semester Block placeholder text

### DIFF
--- a/src/components/PlannerComponents/PlannerCourseHolder.tsx
+++ b/src/components/PlannerComponents/PlannerCourseHolder.tsx
@@ -14,7 +14,7 @@ const PlannerCourseHolder: React.FC<PlannerCourseHolderProps> = ({
       {isHover ? (
         <p>Drop the course!</p>
       ) : (
-        <p>Drag a course here to add it to this semester</p>
+        <p>Drag a course from the Toolbox</p>
       )}
     </div>
   );

--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -1,10 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 import SemesterBlock from "../components/PlannerComponents/SemesterBlocks/SemesterBlock";
 import AddSemester from "../components/PlannerComponents/AddSemester";
 import DeleteSemester from "../components/PlannerComponents/DeleteSemester";
 import { useCourseWorkspace } from "../hooks/useCourseWorkspace";
+import { useNavigate } from "react-router-dom";
+import useIsDesktop from "../hooks/useIsDesktop";
 
 const Planner: React.FC = () => {
+  const navigate = useNavigate();
+  const isDesktop = useIsDesktop();
+
+  useEffect(() => {
+    if (isDesktop) {
+      navigate("/");
+    }
+  }, [isDesktop, navigate]);
+
   const { plannerCourses, setPlannerCourses, setToolboxCourses } =
     useCourseWorkspace();
 
@@ -12,7 +23,7 @@ const Planner: React.FC = () => {
     setPlannerCourses((prev) =>
       prev
         .filter((s) => s.semesterNumber !== semesterNumber)
-        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 })),
+        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 }))
     );
   };
 

--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -23,7 +23,7 @@ const Planner: React.FC = () => {
     setPlannerCourses((prev) =>
       prev
         .filter((s) => s.semesterNumber !== semesterNumber)
-        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 }))
+        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 })),
     );
   };
 

--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -41,6 +41,7 @@ const Planner: React.FC = () => {
                 setPlannerCourses={setPlannerCourses}
                 setToolboxCourses={setToolboxCourses}
               />
+
               <DeleteSemester
                 semesterNumber={semester.semesterNumber}
                 onDelete={handleDeleteSemester}


### PR DESCRIPTION
This pull request holds changes to ```Planner.tsx``` and ```PlannerCourseHolder.tsx```

### Changes made to ```PlannerCourseHolder.tsx```
- Changed the placeholder text from ```Drag a course here to add it to this semester``` to ```Drag a course from the Toolbox```
- This makes it clear to the user that they must have a course in Toolbox before starting to plan their semesters

### Changes made to ```Planner.tsx```
- The page routes to ```/planner``` when ``` < 1024 px ``` which properly resizes when jumping from ```Planner``` to ```Courses``` pages
- The page automatically navigates to ```/``` which is ```Homepage``` when ```≥ 1024 px```
