### PR TITLE
Edit Prettier check to run on all branches

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,14 +1,7 @@
 name: Prettier Check
 
-# Trigger the workflow on push or pull request to main
-on:
-  push:
-    branches:
-      - main
-      - main-preview
-  pull_request:
-    branches:
-      - main
+# Trigger the workflow on all pushes and pull requests
+on: [push, pull_request]
 
 jobs:
   prettier-check:

--- a/src/components/PlannerComponents/SemesterBlock.tsx
+++ b/src/components/PlannerComponents/SemesterBlock.tsx
@@ -30,7 +30,7 @@ const SemesterBlock: React.FC<SemesterBlockProps> = ({ index, semester }) => {
   const hasDuplicateCourses = semester.courseList.some((course, index) => {
     return (
       semester.courseList.findIndex(
-        (c) => c.data.title === course.data.title
+        (c) => c.data.title === course.data.title,
       ) !== index
     );
   });
@@ -41,8 +41,8 @@ const SemesterBlock: React.FC<SemesterBlockProps> = ({ index, semester }) => {
       prevCourses.map((sem) =>
         sem.semesterID === semester.semesterID
           ? { ...sem, season: newSeason }
-          : sem
-      )
+          : sem,
+      ),
     );
   };
 
@@ -50,7 +50,7 @@ const SemesterBlock: React.FC<SemesterBlockProps> = ({ index, semester }) => {
     setPlannerCourses((prev) =>
       prev
         .filter((s) => s.semesterNumber !== semesterNumber)
-        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 }))
+        .map((s, idx) => ({ ...s, semesterNumber: idx + 1 })),
     );
   };
 

--- a/src/components/Toolbox/Toolbox.tsx
+++ b/src/components/Toolbox/Toolbox.tsx
@@ -18,7 +18,7 @@ const Toolbox: React.FC = () => {
 
   useEffect(() => {
     setCount(
-      toolboxCourses.reduce((total, course) => total + (course.count || 0), 0)
+      toolboxCourses.reduce((total, course) => total + (course.count || 0), 0),
     );
   }, [toolboxCourses]);
 


### PR DESCRIPTION
## What?

This pull request formats all existing code in the `main-preview` branch to adhere to Prettier standards, as well as modifies the Prettier check GitHub Action to run on all branches for push and pull request events, not just on `main` and `main-preview`.

## Why?

Previously we were getting confused as to why our GitHub Actions fails only on `main-preview`. Turns out the Prettier check wasn't actually running on branches outside of `main-preview`.

We also love enforcing opinionated code formatting everywhere in our development, so this pull request will do just that.

## How?

I ran Prettier write on all the frontend code and modified the Prettier check YML.

## Testing?

The Prettier check runs and passes on the latest commit of this branch.

## Anything Else?

Have a nice day.