### PR TITLE
Fixing Semester Logic

### DIFF
--- a/src/core/workspace/actions/usePlannerActions.ts
+++ b/src/core/workspace/actions/usePlannerActions.ts
@@ -77,13 +77,17 @@ export const usePlannerActions = (
   );
 
   const addSemester = useCallback(() => {
+    const maxSemesterNumber = plannerSemesters.reduce(
+      (max, s) => Math.max(max, s.semesterNumber),
+      0,
+    );
     dispatch({
       type: "ADD_SEMESTER",
       payload: {
-        semester: generateEmptySemester(plannerSemesters.length + 1),
+        semester: generateEmptySemester(maxSemesterNumber + 1),
       },
     });
-  }, [dispatch, plannerSemesters.length]);
+  }, [dispatch, plannerSemesters]);
 
   const moveSemester = useCallback(
     (fromIndex: number, toIndex: number) => {


### PR DESCRIPTION
Previously, addSemester used plannerSemesters.length + 1 to assign the new semester's number, which could produce duplicates if semesters were deleted out of order. Now it finds the max existing semesterNumber and increments from that.

https://github.com/user-attachments/assets/d1d7ea08-d47c-43f8-9adc-d12cf92eba49

Fixes: #89 

