### PR TITLE
Screen size adapations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,14 +85,20 @@ export default function App() {
   return (
     <CourseWorkspaceProvider>
       <AppDragDropContext>
-        <Router>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/catalog" element={<Catalog />} />
-            <Route path="/planner" element={<Planner />} />
-          </Routes>
-          <Toolbox />
-        </Router>
+        <div className="m-4 md:m-8 md:max-h-dvh overflow-hidden">
+          <header className="sticky top-0 flex h-20 items-center justify-center bg-carpipink">
+            <img src="/carpi-black.png" alt="Carpi Logo" className="h-full" />
+          </header>
+
+          <Router>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/catalog" element={<Catalog />} />
+              <Route path="/planner" element={<Planner />} />
+            </Routes>
+            <Toolbox />
+          </Router>
+        </div>
       </AppDragDropContext>
     </CourseWorkspaceProvider>
   );

--- a/src/features/toolbox/Toolbox.tsx
+++ b/src/features/toolbox/Toolbox.tsx
@@ -113,15 +113,15 @@ export default function Toolbox() {
               ).current = node;
             }}
             onWheel={handleWheel}
-            className="gap-4 scrollbar-none flex items-center w-full overflow-x-auto p-4 mb-14 h-fit md:mb-0"
+            className="gap-4 scrollbar-none flex items-center w-full overflow-x-auto p-4 -mt-4 mb-14 h-fit lg:mb-0"
           >
             <SortableContext
               items={courseIds}
               strategy={horizontalListSortingStrategy}
             >
               {toolboxCourses.length === 0 ? (
-                <div className="md:absolute w-full h-full inset-0 flex items-center justify-center pointer-events-none">
-                  <span className="text-carpipink opacity-60 text-sm md:text-base font-medium italic">
+                <div className="w-full h-full flex items-center justify-center pointer-events-none">
+                  <span className="text-carpipink opacity-60 text-base font-medium italic mb-4">
                     Add courses to plan your semester
                   </span>
                 </div>

--- a/src/features/toolbox/Toolbox.tsx
+++ b/src/features/toolbox/Toolbox.tsx
@@ -113,7 +113,7 @@ export default function Toolbox() {
               ).current = node;
             }}
             onWheel={handleWheel}
-            className="gap-4 scrollbar-none flex items-center w-full overflow-x-auto p-4 -mt-4 mb-14 h-fit lg:mb-0"
+            className="gap-4 scrollbar-none flex items-center w-full overflow-x-auto p-4 -mt-4 mb-14 h-fit md:mb-0"
           >
             <SortableContext
               items={courseIds}

--- a/src/lib/hooks/useIsDesktop.ts
+++ b/src/lib/hooks/useIsDesktop.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 const DESKTOP_BREAKPOINT = 768;
 const useIsDesktop = () => {
   const [isDesktop, setIsDesktop] = useState(
-    window.innerWidth > DESKTOP_BREAKPOINT,
+    window.innerWidth >= DESKTOP_BREAKPOINT,
   );
 
   useEffect(() => {

--- a/src/lib/hooks/useIsDesktop.ts
+++ b/src/lib/hooks/useIsDesktop.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-const DESKTOP_BREAKPOINT = 1024;
+const DESKTOP_BREAKPOINT = 768;
 const useIsDesktop = () => {
   const [isDesktop, setIsDesktop] = useState(
     window.innerWidth > DESKTOP_BREAKPOINT,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,21 +6,15 @@ const HomePage = () => {
   const isDesktop = useIsDesktop();
 
   return (
-    <div className="m-4 md:m-8 md:max-h-dvh overflow-hidden">
-      <header className="sticky top-0 flex h-20 items-center justify-center bg-carpipink">
-        <img src="/carpi-black.png" alt="Carpi Logo" className="h-full" />
-      </header>
-
-      <div className="flex flex-row gap-8">
-        <div className={isDesktop ? "w-1/3" : "w-full"}>
-          <Catalog />
-        </div>
-        {isDesktop && (
-          <div className="w-2/3">
-            <Planner />
-          </div>
-        )}
+    <div className="flex flex-row gap-8">
+      <div className={isDesktop ? "w-1/3" : "w-full"}>
+        <Catalog />
       </div>
+      {isDesktop && (
+        <div className="w-2/3">
+          <Planner />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/Planner.tsx
+++ b/src/pages/Planner.tsx
@@ -23,10 +23,6 @@ const Planner: React.FC = () => {
 
   return (
     <div className="md:h-[calc(100vh-10rem)] md:m-0 m-4 h-screen">
-      <header className="md:hidden flex h-20 items-center justify-center bg-carpipink mt-4">
-        <img src="/carpi-black.png" alt="Carpi Logo" className="h-full" />
-      </header>
-
       <section className="h-full w-full flex flex-col gap-4">
         <div className="flex justify-between sticky top-0 z-10 bg-carpipink pt-4">
           <h1 className="font-bold text-xl">Planner</h1>


### PR DESCRIPTION
This PR addresses two issues ( #95 and #94 ).

Both of these problems occurred as a result of the desktop breakpoint in `useIsDesktop` not being the same as tailwind breakpoints. The hooks breakpoint for desktop was set to be equal to the `md` value in tailwind for consistency.

For further consistency, the CARPI logo has been moved into `App.tsx`, instead of being rendered conditionally in the pages.