### PR TITLE
Update prettier-check.yml

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -9,13 +9,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Node.js (needed for Prettier)
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
Node 16 is depreciated and causing `npm i` errors. This updates the node version and github version.