### PR TITLE
CSS Loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,3 @@
-import "@/index.css";
-
 import { StrictMode } from "react";
 
 import { createRoot } from "react-dom/client";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
+import "@/index.css";
+
 import { StrictMode } from "react";
 
 import { createRoot } from "react-dom/client";
 
 import App from "@/App";
-import "@/index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
There was an issue with CSS not loading on the first load. Apparently this happens bc tailwind updates CSS lazily which means that styling is painted on after the Vite loads the javascript. 

According to gemini and copilot, this is only a known issue on dev environments and is ok on prod, but I just included `index.css` to force styles to be applied when the HTML loads. Just for extra precautions. The problem seems to be solved now.