### PR TITLE
Disable mobile hold for options functionaility

### DIFF
--- a/src/components/course/Course.tsx
+++ b/src/components/course/Course.tsx
@@ -12,7 +12,7 @@ import CourseMenuContent from "@/features/planner/components/course/CourseMenuCo
 import CreditSelector from "@/features/planner/components/CreditSelector";
 import { usePlannerCourse } from "@/features/planner/usePlannerCourse";
 import { cn } from "@/lib/classnames";
-import useIsDesktop from "@/lib/hooks/useIsDesktop";
+import useIsTouch from "@/lib/hooks/useIsTouch";
 import { UserCourse } from "@/lib/types";
 
 type CourseVariant = "toolbox" | "planner";
@@ -97,7 +97,7 @@ function PlannerCourseView({
     semesterId: semesterId ?? null,
   });
 
-  const isDesktop = useIsDesktop();
+  const isTouch = useIsTouch();
   const [popoverOpen, setPopoverOpen] = useState(false);
 
   if (!semesterId) {
@@ -112,7 +112,7 @@ function PlannerCourseView({
 
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger disabled={!isDesktop}>
+      <ContextMenu.Trigger disabled={!isTouch} asChild>
         <div
           ref={innerRef}
           className={cn(

--- a/src/components/course/Course.tsx
+++ b/src/components/course/Course.tsx
@@ -12,6 +12,7 @@ import CourseMenuContent from "@/features/planner/components/course/CourseMenuCo
 import CreditSelector from "@/features/planner/components/CreditSelector";
 import { usePlannerCourse } from "@/features/planner/usePlannerCourse";
 import { cn } from "@/lib/classnames";
+import useIsDesktop from "@/lib/hooks/useIsDesktop";
 import { UserCourse } from "@/lib/types";
 
 type CourseVariant = "toolbox" | "planner";
@@ -95,6 +96,8 @@ function PlannerCourseView({
     course,
     semesterId: semesterId ?? null,
   });
+
+  const isDesktop = useIsDesktop();
   const [popoverOpen, setPopoverOpen] = useState(false);
 
   if (!semesterId) {
@@ -109,7 +112,7 @@ function PlannerCourseView({
 
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger>
+      <ContextMenu.Trigger disabled={!isDesktop}>
         <div
           ref={innerRef}
           className={cn(

--- a/src/lib/hooks/useIsTouch.ts
+++ b/src/lib/hooks/useIsTouch.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+export default function useIsTouch() {
+  // Default to true (or false) for SSR, but true is often safer for desktop-first contexts
+  // Alternatively, just start with false to strictly require the capability to be proven.
+  const [isTouch, setIsTouch] = useState(true);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(pointer: fine)");
+
+    // Set initial value
+    setIsTouch(mediaQuery.matches);
+
+    // Listen for changes (e.g., user plugs in a mouse to a tablet)
+    const handler = (e: MediaQueryListEvent) => setIsTouch(e.matches);
+
+    // Use modern addEventListener
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handler);
+      return () => mediaQuery.removeEventListener("change", handler);
+    }
+    // Fallback for older browsers if needed
+    else if (mediaQuery.addListener) {
+      mediaQuery.addListener(handler);
+      return () => mediaQuery.removeListener(handler);
+    }
+  }, []);
+
+  return isTouch;
+}


### PR DESCRIPTION
On mobile devices, long holds are usually translated into right click actions on the web. There was a right click context implemented for all planner courses and the long hold was causing a problem on mobile devices. To fix, this it was just disabled.
