### PR TITLE
Course Tweeks

### DIFF
--- a/src/core/workspace/utils/io/inputOutput.ts
+++ b/src/core/workspace/utils/io/inputOutput.ts
@@ -68,7 +68,7 @@ export const enrichCourseForImport = (exported: ExportCourse): UserCourse => {
     count: exported.count || 1,
     data: {
       subj_code: exported.code.split(" ")[0],
-      code_num: parseInt(exported.code.split(" ")[1]),
+      code_num: exported.code.split(" ")[1],
       title: exported.title,
       desc_text: exported.course_info.description,
       credit_min: exported.course_info.credit_min,

--- a/src/core/workspace/utils/schemas.ts
+++ b/src/core/workspace/utils/schemas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 /* API SCHEMAS */
 export const APICourseSchema = z.object({
   subj_code: z.string(),
-  code_num: z.coerce.number(),
+  code_num: z.coerce.string(),
   title: z.string(),
   desc_text: z.string(),
   credit_min: z.coerce.number(),

--- a/src/features/catalog/components/CatalogCourse.tsx
+++ b/src/features/catalog/components/CatalogCourse.tsx
@@ -43,7 +43,7 @@ const Course: React.FC<CourseProps> = ({ course }) => {
 
   return (
     <div
-      className="relative bg-carpipink hover:cursor-pointer hover:bg-darkblue/10 border-1 border-black rounded-xl w-full p-4"
+      className="hover:cursor-pointer hover:bg-darkblue/10 border border-black rounded-xl w-full p-4"
       onClick={toggleOpen}
     >
       <CourseBadge

--- a/src/features/planner/components/semester/SemesterBlock.tsx
+++ b/src/features/planner/components/semester/SemesterBlock.tsx
@@ -82,7 +82,9 @@ export default function SemesterBlock({ semester, index }: SemesterBlockProps) {
   const hasDuplicateCourses = semester.courseList.some((course, index) => {
     return (
       semester.courseList.findIndex(
-        (c) => c.data.title === course.data.title,
+        (c) =>
+          c.data.subj_code === course.data.subj_code &&
+          c.data.code_num === course.data.code_num,
       ) !== index
     );
   });

--- a/src/lib/types/course.ts
+++ b/src/lib/types/course.ts
@@ -1,6 +1,6 @@
 export interface APICourse {
   subj_code: string;
-  code_num: number;
+  code_num: string;
   title: string;
   desc_text: string;
   credit_min: number;


### PR DESCRIPTION
This PR fixes two course related bugs that were found:
- Course comparisons on the semester (similar courses are now determined by their `subj_code` and `code_num`)
- Previously, when reloading a course it would get truncated. This has been fixed by storing `code_num` as a string rather than a number